### PR TITLE
Fixpetrarch2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,29 +36,59 @@ Example Python Usage
 
 ```
 import requests
-import json
+import json 
+from pprint import pprint
 
 headers = {'Content-Type': 'application/json'}
-data = {'text': "At least 37 people are dead after Islamist radical group Boko Haram assaulted a town in northeastern Nigeria.", 'id': 'abc123', 'date':
-'20010101'}
+data = {'text':"A Tunisian court has jailed a Nigerian student for two years for helping young militants join an armed Islamic group in Lebanon, his lawyer said Wednesday.", 'id': 'abc123', 'date':'20010101'}
 data = json.dumps(data)
-r = requests.get('http://localhost:5002/hypnos/extract', data=data,
-                 headers=headers)
-r.json()
+r = requests.get('http://localhost:5002/hypnos/extract', data=data, headers=headers)
+pprint(r.json())
 ```
 
 Returns:
 
 ```
-{u'abc123': {u'meta': {u'date': u'20010101'},
-  u'sents': {u'0': {u'content': u'At least 37 people are dead after Islamist
-  radical group Boko Haram assaulted a town in northeastern Nigeria .',
-      u'events': [[u'NGAREBMUS', u'NGA', u'190']],
-          u'issues': [[u'ID_EXTREMISM', 1], [u'NAMED_TERROR_GROUP', 1]],
-              u'parsed': u'(ROOT (S (NP (QP (IN AT ) (JJS LEAST ) (CD 37 ) )
-              (NNS PEOPLE ) ) (VP (VBP ARE ) (ADJP (JJ DEAD ) ) (SBAR (IN AFTER
-              ) (S (NP (JJ ISLAMIST ) (JJ RADICAL ) (NN GROUP ) (NNP BOKO )
-              (NNP HARAM ) ) (VP (VBD ASSAULTED ) (NP (NP (DT A ) (NN TOWN ) )
-              (PP (IN IN ) (NP (JJ NORTHEASTERN ) (NNP NIGERIA ) ) ) ) ) ) ) )
-              (. . ) ) )'}}}}
+{'abc123': {'meta': {'date': '20010101', 'verbs': []},
+            'sents': {'0': {'content': 'A Tunisian court has jailed a Nigerian '
+                                       'student for two years for helping '
+                                       'young militants join an armed Islamic '
+                                       'group in Lebanon , his lawyer said '
+                                       'Wednesday .',
+                            'events': [['TUNJUD', 'NGAEDU', '173']],
+                            'issues': [['STUDENTS', 1],
+                                       ['NAMED_TERROR_GROUP', 1]],
+                            'meta': {'actorroot': [['', '']],
+                                     'actortext': [['Tunisian court',
+                                                    'Nigerian student']],
+                                     'eventtext': ['has jailed'],
+                                     'nouns': [[[' TUNISIAN', ' COURT'],
+                                                ['TUNJUD'],
+                                                [['TUN', []], ['~']]],
+                                               [[' NIGERIAN', ' STUDENT'],
+                                                ['NGAEDU'],
+                                                [['NGA', []], ['~']]],
+                                               [[' ARMED ISLAMIC GROUP'],
+                                                ['DZAREB'],
+                                                [['DZAREB', []]]],
+                                               [[' LEBANON'],
+                                                ['LBN'],
+                                                [['LBN', []]]],
+                                               [[' LAWYER'],
+                                                ['~JUD'],
+                                                [['~']]]]},
+                            'parsed': '(SBAR (S (NP (DT A )  (JJ TUNISIAN )  '
+                                      '(NN COURT )  )  (VP (VBZ HAS )  (VP '
+                                      '(VBN JAILED )  (NP (DT A )  (JJ '
+                                      'NIGERIAN )  (NN STUDENT )  )  (PP (IN '
+                                      'FOR )  (NP (CD TWO )  (NNS YEARS )  )  '
+                                      ')  (PP (IN FOR )  (S (VP (VBG HELPING '
+                                      ')  (NP (JJ YOUNG )  (NNS MILITANTS )  '
+                                      ')  )  )  )  )  )  )  (S (VP (VBP JOIN '
+                                      ')  (NP (DT AN )  (JJ ARMED )  (JJ '
+                                      'ISLAMIC )  (NN GROUP )  )  (PP (IN IN '
+                                      ')  (NP (NNP LEBANON )  )  )  )  )  (, , '
+                                      ')  (S (NP (PRP$ HIS )  (NN LAWYER )  )  '
+                                      '(VP (VBD SAID )  (NP (NNP WEDNESDAY )  '
+                                      ')  )  )  (. . )  )  '}}}}
 ```

--- a/petrarch/petrarch_app.py
+++ b/petrarch/petrarch_app.py
@@ -12,6 +12,11 @@ api = Api(app)
 
 cwd = os.path.abspath(os.path.dirname(__file__))
 
+config = petrarch2.utilities._get_data('data/config/','PETR_config.ini')
+petrarch2.PETRreader.parse_Config(config)
+petrarch2.read_dictionaries()
+#print(config)
+#print(getattr(petrarch2,"VerbDict"))
 
 @app.errorhandler(400)
 def bad_request(error):
@@ -39,6 +44,21 @@ class CodeAPI(Resource):
         except Exception as e:
             sys.stderr.write("An error occurred with PETR. {}\n".format(e))
             event_dict_updated = event_dict
+        
+        for key in event_dict_updated:
+            event_dict_updated[key]['meta']['verbs']=[]
+            for sent in event_dict_updated[key]['sents']:
+                try:
+                    temp_meta = event_dict_updated[key]['sents'][sent]['meta']
+                    event_dict_updated[key]['sents'][sent]['meta']={'actortext':list(temp_meta['actortext'].values()),
+                        'eventtext':list(temp_meta['eventtext'].values()),
+                        'nouns':temp_meta['nouns'],
+                        'actorroot':list(temp_meta['actorroot'].values())}
+                except:
+                    event_dict_updated[key]['sents'][sent]['meta']={'actortext':[[]],
+                            'eventtext':[[]],
+                            'nouns':[],
+                            'actorroot':[[]]}
 
         return event_dict_updated
 
@@ -46,11 +66,11 @@ class CodeAPI(Resource):
 api.add_resource(CodeAPI, '/petrarch/code')
 
 if __name__ == '__main__':
-    config = petrarch2.utilities._get_data('data/config/', 'PETR_config.ini')
-    print("reading config")
-    petrarch2.PETRreader.parse_Config(config)
-    print("reading dicts")
-    petrarch2.read_dictionaries()
+    #config = petrarch2.utilities._get_data('data/config/', 'PETR_config.ini')
+    #print("reading config")
+    #petrarch2.PETRreader.parse_Config(config)
+    #print("reading dicts")
+    #petrarch2.read_dictionaries()
 
     http_server = HTTPServer(WSGIContainer(app))
     http_server.listen(5001)


### PR DESCRIPTION
I have fixed *hypnos* such that it builds and works despite underlying formatting issues in *petrarch2*. Neither the petrarch2 or corenlp sub-containers are modified. 

Hypnos with Petrarch2 was breaking (see https://github.com/openeventdata/hypnos/issues/4#issue-222910790). This was due, in part, to the following remediated errors:

* Dictionaries failed to load in Petrarch2
* Petrarch2 output dictionary fields were poorly formed (tuple keys) that caused `json.dumps` to fail.
* Petrarch2 function `_format_parsed_str` wasn't being called prior to `do_coding`.

Hypnos docker should now build properly and the example code works properly. I changed the example in the readme because Petrarch2 was not identifying events in the previous example. However, the examples given in the Petrarch2 unit tests work as expected.

The output format is slightly modified to correct for Petrarch2's poorly formatted output, but I anticipate that it will be backwards compatible with the previous output format for all (at least most) applications. 